### PR TITLE
Fix gradlew test errors and improve tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ dependencies {
         exclude group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8"
         exclude group: "javax.validation", module: "validation-api"
     }
+
+    // Supress following logs in gradlew test.
+    // SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+    // SLF4J: Defaulting to no-operation (NOP) logger implementation
+    // SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+    testImplementation("org.slf4j:slf4j-simple:1.7.30")
 }
 embulkPlugin {
     mainClass = "org.embulk.output.DatabricksOutputPlugin"

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ gem {
     homepage = "https://github.com/trocco-io/embulk-output-databricks"
     licenses = [ "MIT" ]
 }
+test {
+    maxParallelForks 1
+}
 spotless {
     java {
         importOrder()

--- a/src/main/java/org/embulk/output/databricks/DatabricksAPIClient.java
+++ b/src/main/java/org/embulk/output/databricks/DatabricksAPIClient.java
@@ -62,6 +62,10 @@ public class DatabricksAPIClient {
     return currentTransactionVolumeName;
   }
 
+  public static void resetFetchCurrentTransactionVolumeName() {
+    currentTransactionVolumeName = null;
+  }
+
   public static String createRandomUnityCatalogObjectName() {
     // https://docs.databricks.com/en/sql/language-manual/sql-ref-names.html
     // https://docs.databricks.com/en/sql/language-manual/sql-ref-identifiers.html

--- a/src/test/java/org/embulk/output/databricks/AbstractTestDatabricksOutputPlugin.java
+++ b/src/test/java/org/embulk/output/databricks/AbstractTestDatabricksOutputPlugin.java
@@ -51,6 +51,7 @@ public abstract class AbstractTestDatabricksOutputPlugin {
       return;
     }
     ConnectionUtil.dropAllTemporaryTables();
+    DatabricksAPIClient.resetFetchCurrentTransactionVolumeName();
     DatabricksApiClientUtil.deleteAllTemporaryStagingVolumes();
   }
 


### PR DESCRIPTION
- Fixed gradle errors with continuous test runs.  (This is caused by a change in Databricks Volume API behavior.)

- Supress undesirable logs in gradlew test. (SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder" ~~)
