### PR TITLE
Update databricks-jdbc:2.6.38

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "com.palantir.git-version" version "0.12.3"
     id "com.diffplug.spotless" version "5.15.0"
     id "com.adarshr.test-logger" version "3.0.0"
+    id "com.github.johnrengelman.shadow" version "6.0.0" apply false
 }
 repositories {
     mavenCentral()
@@ -60,7 +61,7 @@ dependencies {
 
     compile "org.embulk:embulk-output-jdbc:0.10.5"
     compile "org.embulk:embulk-output-postgresql:0.10.5"
-    compile 'com.databricks:databricks-jdbc:2.6.36'
+    compile project(path: ":shadow-databricks-jdbc", configuration: "shadow")
     compile("com.databricks:databricks-sdk-java:0.20.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,7 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.databricks:databricks-jdbc:2.6.36
 com.databricks:databricks-sdk-java:0.20.0
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'embulk-output-databricks'
+include "shadow-databricks-jdbc"

--- a/shadow-databricks-jdbc/build.gradle
+++ b/shadow-databricks-jdbc/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: "java"
+apply plugin: "com.github.johnrengelman.shadow"
+
+repositories {
+    mavenCentral()
+}
+
+group = "io.trocco"
+version = "${rootProject.version}"
+description = "A helper library for embulk-output-databricks"
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+configurations {
+    runtimeClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    shadow {
+        resolutionStrategy.activateDependencyLocking()
+        transitive = false
+    }
+}
+
+dependencies {
+    compile('com.databricks:databricks-jdbc:2.6.38')
+}
+
+shadowJar {
+    // suppress the following undesirable log (https://stackoverflow.com/a/61475766/24393181)
+    //
+    // ERROR StatusLogger Unrecognized format specifier [d]
+    // ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
+    // ...
+    exclude "**/Log4j2Plugins.dat"
+}

--- a/shadow-databricks-jdbc/build/tmp/shadowJar/MANIFEST.MF
+++ b/shadow-databricks-jdbc/build/tmp/shadowJar/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+

--- a/shadow-databricks-jdbc/build/tmp/shadowJar/MANIFEST.MF
+++ b/shadow-databricks-jdbc/build/tmp/shadowJar/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-

--- a/shadow-databricks-jdbc/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/shadow-databricks-jdbc/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.databricks:databricks-jdbc:2.6.38

--- a/shadow-databricks-jdbc/gradle/dependency-locks/shadow.lockfile
+++ b/shadow-databricks-jdbc/gradle/dependency-locks/shadow.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.


### PR DESCRIPTION
Update 'com.databricks:databricks-jdbc:' from 2.6.36 to 2.6.38 and wrap 'com.databricks:databricks-jdbc' in shadow-jar to suppress the following stderr messages.

```
Hidden dependencies are uninitialized. Maybe using classes loaded by Embulk's top-level ClassLoader.
ERROR StatusLogger Unrecognized format specifier [d]
ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [thread]
```
