### PR TITLE
fix: listing table and columns were executed with null category because it specify database name instead of category name.

### DIFF
--- a/src/main/java/org/embulk/output/DatabricksOutputPlugin.java
+++ b/src/main/java/org/embulk/output/DatabricksOutputPlugin.java
@@ -180,11 +180,12 @@ public class DatabricksOutputPlugin extends AbstractJdbcOutputPlugin {
       return Optional.empty();
     }
 
+    DatabricksOutputConnection conn = (DatabricksOutputConnection) connection;
     DatabaseMetaData dbm = connection.getMetaData();
     String escape = dbm.getSearchStringEscape();
 
     ResultSet rs =
-        dbm.getPrimaryKeys(table.getDatabase(), table.getSchemaName(), table.getTableName());
+        dbm.getPrimaryKeys(conn.getCatalogName(), table.getSchemaName(), table.getTableName());
     final HashSet<String> primaryKeysBuilder = new HashSet<>();
     try {
       while (rs.next()) {
@@ -207,7 +208,7 @@ public class DatabricksOutputPlugin extends AbstractJdbcOutputPlugin {
     // https://docs.databricks.com/en/sql/language-manual/data-types/timestamp-ntz-type.html#notes
     rs =
         dbm.getColumns(
-            JdbcUtils.escapeSearchString(table.getDatabase(), escape),
+            JdbcUtils.escapeSearchString(conn.getCatalogName(), escape),
             JdbcUtils.escapeSearchString(table.getSchemaName(), escape),
             JdbcUtils.escapeSearchString(table.getTableName(), escape),
             null);

--- a/src/main/java/org/embulk/output/databricks/DatabricksOutputConnection.java
+++ b/src/main/java/org/embulk/output/databricks/DatabricksOutputConnection.java
@@ -62,6 +62,10 @@ public class DatabricksOutputConnection extends JdbcOutputConnection {
     // null
     // and one Databricks connection has multiple available catalogs　(databases).
 
+    // NOTE: maybe this logic is not necessary anymore after this PR:
+    //    https://github.com/trocco-io/embulk-output-databricks/pull/11
+    // But I'm not sure, so I'll keep it for now.
+
     if (tableIdentifier.getDatabase() == null) {
       logger.trace("tableIdentifier.getDatabase() == null, check by instance variable");
       if (!rs.getString("TABLE_CAT").equalsIgnoreCase(catalogName)) {

--- a/src/main/java/org/embulk/output/databricks/DatabricksOutputConnection.java
+++ b/src/main/java/org/embulk/output/databricks/DatabricksOutputConnection.java
@@ -45,7 +45,7 @@ public class DatabricksOutputConnection extends JdbcOutputConnection {
     try (ResultSet rs =
         connection
             .getMetaData()
-            .getTables(table.getDatabase(), table.getSchemaName(), table.getTableName(), null)) {
+            .getTables(catalogName, table.getSchemaName(), table.getTableName(), null)) {
       while (rs.next()) {
         if (isAvailableTableMetadataInConnection(rs, table)) {
           return true;
@@ -294,5 +294,9 @@ public class DatabricksOutputConnection extends JdbcOutputConnection {
       sb.append(quoteIdentifierString(schema.getColumnName(i)));
     }
     return sb.toString();
+  }
+
+  public String getCatalogName() {
+    return catalogName;
   }
 }


### PR DESCRIPTION
Although getTables / getPrimaryKeys / getColumns expect catalog name, TableIdentifier::getDatabase() doesn't return catalog name. And getDatabase() returns null, so getTables, etc scan all catalogs unfortunatey.

In a user's environment, an error cropped up.  So I need this fix.

