### PR TITLE
Refactoring: remove duplicate code with superclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,6 @@ $ ./gradlew gem  # -t to watch change of files and rebuild continuously
 
 ## TEST
 
+```
 $ EMBULK_OUTPUT_DATABRICKS_TEST_CONFIG="example/test.yml" ./gradlew test # Create example/test.yml based on example/test.yml.example
+```


### PR DESCRIPTION
Refactoring: With [this PR](https://github.com/trocco-io/embulk-output-databricks/pull/11) change, duplicate codes with superclasses that are no longer needed have been removed. see also <https://github.com/trocco-io/embulk-output-databricks/pull/11#issuecomment-2434144623>

Fix readme.md test codeblock.