### PR TITLE
feat: update Databricks JDBC driver to v2.6.40 for GCP OAuth M2M support

### DIFF
--- a/shadow-databricks-jdbc/build.gradle
+++ b/shadow-databricks-jdbc/build.gradle
@@ -23,7 +23,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.databricks:databricks-jdbc:2.6.38')
+    compile('com.databricks:databricks-jdbc:2.6.40')
 }
 
 shadowJar {

--- a/shadow-databricks-jdbc/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/shadow-databricks-jdbc/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.databricks:databricks-jdbc:2.6.38
+com.databricks:databricks-jdbc:2.6.40


### PR DESCRIPTION
- Updated com.databricks:databricks-jdbc from 2.6.38 to 2.6.40
- Enables OAuth Machine-to-Machine (M2M) authentication on Google Cloud Platform
